### PR TITLE
Less strict restriction for reactor projects using tiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
+# Ignore hidden files
+.*
+**/.*
+
+# Ignore target directory
 target
+
+# Don't ignore git special files
+!.gitignore
+!.gitattributes
+!.gitkeep

--- a/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
@@ -221,21 +221,27 @@ public class TilesMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 		this.modelCache = new NotDefaultModelCache(mavenSession)
 
 		List<MavenProject> allProjects = mavenSession.getAllProjects()
-		for (MavenProject currentProject : allProjects) {
-			List<String> subModules = currentProject.getModules()
-			boolean containsTiles = currentProject.getPluginArtifactMap().keySet().contains("io.repaint.maven:tiles-maven-plugin")
+        for (MavenProject currentProject : allProjects) {
+            List<String> subModules = currentProject.getModules()
+            boolean containsTiles = currentProject.getPluginArtifactMap().keySet().contains("io.repaint.maven:tiles-maven-plugin")
 
-			if (containsTiles) {
-				if (subModules != null && subModules.size() > 0) {
-					//We're in project with children, fail the build immediate. This is both an opinionated choice, but also
-					//one of project health - with tile definitions in parent POMs usage of -pl, -am, and -amd maven options
-					//are limited.
-					throw new MavenExecutionException("Usage of maven-tiles prohibited from multi-module builds.", currentProject.getFile())
-				} else {
-					orchestrateMerge(currentProject)
-				}
-			}
-		}
+            if (containsTiles) {
+                if (subModules != null && !subModules.isEmpty()) {
+                    Model currentModel = currentProject.getModel();
+                    for (MavenProject otherProject : allProjects) {
+                        Parent otherParent = otherProject.getModel().getParent()
+                        if(otherParent!=null && parentGav(otherParent).equals(modelGav(currentModel))) {
+                            //We're in project with children, fail the build immediate. This is both an opinionated choice, but also
+                            //one of project health - with tile definitions in parent POMs usage of -pl, -am, and -amd maven options
+                            //are limited.
+                            throw new MavenExecutionException("Usage of maven-tiles prohibited from multi-module builds where reactor is used as parent.", currentProject.getFile())
+                        }
+                    }
+                }
+
+                orchestrateMerge(currentProject)
+            }
+        }
 	}
 
 	/**


### PR DESCRIPTION
Fail build only if the reactor is used as parent POM by one of its module.
Also successfully tested partial builds with -pl, -am and -amd flags.