### PR TITLE
Copy groupId/version from original parent if inherited (Fixes #47)

### DIFF
--- a/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
@@ -501,6 +501,16 @@ public class TilesMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 		if (tiles) {
 			logger.info("--- tiles-maven-plugin: Injecting ${tiles.size()} tiles as intermediary parent artifact's...")
 			logger.info("Mixed '${modelGav(pomModel)}' with tile '${modelGav(tiles.first().model)}' as it's new parent.")
+			
+			// if there is a parent make sure the inherited groupId / version is correct
+			if (!pomModel.groupId) {
+				pomModel.groupId = originalParent.groupId
+				logger.info("Explicitly set groupId to '${pomModel.groupId}' from original parent '${parentGav(originalParent)}'.")
+			}
+			if (!pomModel.version) {
+				pomModel.version = originalParent.version
+				logger.info("Explicitly set version to '${pomModel.version}' from original parent '${parentGav(originalParent)}'.")
+			}
 		}
 
 		tiles.each { TileModel tileModel ->


### PR DESCRIPTION
If the model does not define an explicit groupId and/or version it needs to be explicitly copied from the parent, as otherwise those values would be taken from the tile's POM. 