### PR TITLE
Optionally apply tiles before specific parent

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -205,6 +205,48 @@ If you don't wish to include `<repository>` definitions in your project source, 
 
 NOTE: This introduces an element of inconsistentcy/non-reproducability to your build and should be done with care.
 
+== Parent structure
+
+Tiles will always be applied as parents of the project that is built. Any orignal parent of that project will be added
+as the parent of the last applied tile. So if you apply Tiles `T1` and `T2` to a project `X` with a parent `P`, the 
+resulting hierarchy will be `X` - `T1` - `T2` - `P`. Thus (see section _Additional Notes_), the definitions in the parent
+can be overwritten by a tile, but not the other way around.
+
+However, there are situations where you want to define your tiles in a parent, e.g. when you have a lot of artifacts
+that are built in the same way. In this case you would want a structure like this: `X` - `P` - `T1` - `T2`. While you'd
+maybe expect it to work this way if the tiles are included in `P`, due to the way Maven works there's no way to know
+where a configuration comes from. To still enable this use case you can manually choose a parent where the tiles will
+be applied (in this case before `P`) resulting in the desired structure:
+
+[source,xml,indent=0]
+.pom.xml
+----
+<parent>
+	<groupId>group</groupId>
+	<artifactId>P</artifactId>
+	<version>1.0.0</version>
+</parent>
+<artifactId>X</artifactId>
+...
+<build>
+  <plugins>
+    <plugin>
+      <groupId>io.repaint.maven</groupId>
+      <artifactId>tiles-maven-plugin</artifactId>
+      <version>2.7</version>
+      <configuration>
+        <applyBefore>group:P</applyBefore>
+        <tiles>
+          <tile>group:T1:1.0.0</tile>
+          <tile>group:T2:1.0.0</tile>
+        </tiles>
+      </configuration>
+    </plugin>
+  </plugins>
+</build>
+----
+
+
 == Mojos
 
 There are two mojos in the plugin, attach-tile and validate. attach-tile is only used by the deploy/install

--- a/src/main/groovy/io/repaint/maven/tiles/AbstractTileMojo.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/AbstractTileMojo.groovy
@@ -25,6 +25,9 @@ abstract class AbstractTileMojo extends AbstractMojo {
 
 	@Parameter(property = "tiles", readonly = false, required = false)
 	List<String> tiles
+	
+	@Parameter(property = "applyBefore", readonly = false, required = false)
+	String applyBefore;
 
 	@Parameter(property = "buildSmells", readonly = false, required = false)
 	String buildSmells

--- a/src/main/groovy/io/repaint/maven/tiles/GavUtil.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/GavUtil.groovy
@@ -19,6 +19,10 @@ class GavUtil {
 	public static String modelGav(Model model) {
 		return String.format("%s:%s:%s", model.groupId, model.artifactId, model.version)
 	}
+	
+	public static String modelGa(Model model) {
+		return String.format("%s:%s", model.groupId, model.artifactId)
+	}
 
 	public static String parentGav(Parent model) {
 		if (!model) {


### PR DESCRIPTION
Instead of always injecting tiles after the current project's model
(before the first parent), in a build where the tiles are actually defined
in a parent pom we want to apply them before that specific parent.

As we cannot find out easily where exactly a tile has been included, 
we can at least allow to specify before which parent the tiles are to be
injected. In that case however, all parents between the project's model 
and the parent where the tiles are applied to need to be duplicated per
project, as they might have different parents (-> the tiles)

The parent which is to "inherit" the tiles can be specified with 
`<applyBefore>[the specific parent as groupId:artifactId:version]</applyBefore>`
in the tiles' configuration.
