### PR TITLE
Filter tiles in reactor

### DIFF
--- a/src/main/groovy/io/repaint/maven/tiles/AbstractTileMojo.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/AbstractTileMojo.groovy
@@ -1,16 +1,15 @@
 package io.repaint.maven.tiles
+
 import groovy.transform.CompileStatic
 import org.apache.maven.execution.MavenSession
-import org.apache.maven.model.Resource
 import org.apache.maven.plugin.AbstractMojo
 import org.apache.maven.plugins.annotations.Component
 import org.apache.maven.plugins.annotations.Parameter
 import org.apache.maven.project.MavenProject
 import org.apache.maven.shared.filtering.MavenFileFilter
-import org.apache.maven.shared.filtering.MavenFileFilterRequest
-import org.apache.maven.shared.filtering.MavenResourcesExecution
 import org.apache.maven.shared.filtering.MavenResourcesFiltering
 import org.codehaus.plexus.logging.Logger
+
 /**
  *
  * @author: Richard Vowles - https://plus.google.com/+RichardVowles
@@ -18,7 +17,6 @@ import org.codehaus.plexus.logging.Logger
  */
 @CompileStatic
 abstract class AbstractTileMojo extends AbstractMojo {
-	public static final String TILE_POM = "tile.xml"
 
 	@Parameter(property = "project", readonly = true, required = true)
 	MavenProject project
@@ -36,7 +34,7 @@ abstract class AbstractTileMojo extends AbstractMojo {
 	boolean filtering
 
 	@Parameter(required = true, defaultValue = '${project.build.directory}/generated-sources')
-	protected File generatedSourcesDirectory;
+	File generatedSourcesDirectory
 
 	@Component
 	Logger logger
@@ -51,30 +49,7 @@ abstract class AbstractTileMojo extends AbstractMojo {
 	MavenResourcesFiltering mavenResourcesFiltering
 
 	File getTile() {
-		File baseTile = new File(project.basedir, TILE_POM)
-		if (filtering) {
-			File processedTileDirectory = new File(generatedSourcesDirectory, "tiles")
-			processedTileDirectory.mkdirs()
-			File processedTile = new File(processedTileDirectory, TILE_POM)
-
-			Resource tileResource = new Resource()
-			tileResource.setDirectory(project.basedir.absolutePath);
-			tileResource.includes.add(TILE_POM)
-			tileResource.setFiltering(true)
-
-			MavenFileFilterRequest req = new MavenFileFilterRequest(baseTile, processedTile, true, project, [], true, "UTF-8", mavenSession, new Properties())
-			req.setDelimiters(["@"] as LinkedHashSet)
-
-			MavenResourcesExecution execution = new MavenResourcesExecution(
-					[tileResource], processedTileDirectory, "UTF-8",
-					mavenFileFilter.getDefaultFilterWrappers(req),
-					project.basedir, mavenResourcesFiltering.defaultNonFilteredFileExtensions)
-
-			mavenResourcesFiltering.filterResources(execution)
-
-			return new File(processedTileDirectory, TILE_POM)
-		} else {
-			return baseTile
-		}
+		return FilteringHelper.getTile(project, filtering, generatedSourcesDirectory, mavenSession, mavenFileFilter, mavenResourcesFiltering)
 	}
+
 }

--- a/src/main/groovy/io/repaint/maven/tiles/FilteringHelper.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/FilteringHelper.groovy
@@ -1,0 +1,84 @@
+package io.repaint.maven.tiles
+
+import groovy.transform.CompileStatic
+import groovy.transform.TypeCheckingMode
+import org.apache.maven.execution.MavenSession
+import org.apache.maven.model.Plugin
+import org.apache.maven.model.Resource
+import org.apache.maven.project.MavenProject
+import org.apache.maven.shared.filtering.MavenFileFilter
+import org.apache.maven.shared.filtering.MavenFileFilterRequest
+import org.apache.maven.shared.filtering.MavenResourcesExecution
+import org.apache.maven.shared.filtering.MavenResourcesFiltering
+
+import static io.repaint.maven.tiles.Constants.TILEPLUGIN_ARTIFACT
+import static io.repaint.maven.tiles.Constants.TILEPLUGIN_GROUP
+import static io.repaint.maven.tiles.Constants.TILE_POM
+
+@CompileStatic
+class FilteringHelper {
+
+    @CompileStatic(TypeCheckingMode.SKIP)
+    static File getTile(final MavenProject project,
+                        final MavenSession mavenSession,
+                        final MavenFileFilter mavenFileFilter,
+                        final MavenResourcesFiltering mavenResourcesFiltering) {
+        // determine whether filtering is enabled
+        def configuration = project.build.plugins
+            ?.find({ Plugin plugin -> plugin.groupId == TILEPLUGIN_GROUP && plugin.artifactId == TILEPLUGIN_ARTIFACT})
+            ?.configuration
+
+        final boolean filtering = configuration?.getChild("filtering")?.getValue() == "true"
+
+        if (filtering) {
+            String generatedSourcesDirectoryStr = configuration?.getChild("generatedSourcesDirectory")?.getValue()
+            File generatedSourcesDirectory = generatedSourcesDirectoryStr
+                ? new File(generatedSourcesDirectoryStr) : new File(project.build.directory, "generated-sources")
+            return getTile(project, true, generatedSourcesDirectory, mavenSession, mavenFileFilter, mavenResourcesFiltering)
+        } else {
+            return getTile(project, false, null, mavenSession, null, null)
+        }
+    }
+
+    static File getTile(final MavenProject project,
+                        final boolean filtering,
+                        final File generatedSourcesDirectory,
+                        final MavenSession mavenSession,
+                        final MavenFileFilter mavenFileFilter,
+                        final MavenResourcesFiltering mavenResourcesFiltering) {
+        File baseTile = new File(project.basedir, TILE_POM)
+        if (filtering) {
+            File processedTileDirectory = new File(generatedSourcesDirectory, "tiles")
+            processedTileDirectory.mkdirs()
+            File processedTile = new File(processedTileDirectory, TILE_POM)
+
+            Resource tileResource = new Resource()
+            tileResource.setDirectory(project.basedir.absolutePath)
+            tileResource.includes.add(TILE_POM)
+            tileResource.setFiltering(true)
+
+            MavenFileFilterRequest req = new MavenFileFilterRequest(baseTile,
+                    processedTile,
+                    true,
+                    project,
+                    [],
+                    true,
+                    "UTF-8",
+                    mavenSession,
+                    new Properties())
+            req.setDelimiters(["@"] as LinkedHashSet)
+
+            MavenResourcesExecution execution = new MavenResourcesExecution(
+                    [tileResource], processedTileDirectory, "UTF-8",
+                    mavenFileFilter.getDefaultFilterWrappers(req),
+                    project.basedir, mavenResourcesFiltering.defaultNonFilteredFileExtensions)
+
+            mavenResourcesFiltering.filterResources(execution)
+
+            return new File(processedTileDirectory, TILE_POM)
+        } else {
+            return baseTile
+        }
+    }
+
+}

--- a/src/main/groovy/io/repaint/maven/tiles/NotDefaultModelCache.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/NotDefaultModelCache.groovy
@@ -1,7 +1,11 @@
 package io.repaint.maven.tiles
 
+import groovy.transform.CompileStatic
+import groovy.transform.TypeCheckingMode
 import org.apache.maven.execution.MavenSession
 import org.apache.maven.model.building.ModelCache
+import org.eclipse.aether.RepositoryCache
+import org.eclipse.aether.RepositorySystemSession
 
 /**
  * Because the Default one is package private *sigh*
@@ -10,74 +14,64 @@ import org.apache.maven.model.building.ModelCache
  *
  * @author: Richard Vowles - https://plus.google.com/+RichardVowles
  */
+@CompileStatic
 class NotDefaultModelCache implements ModelCache {
-	def session
-	def cache
 
-	public NotDefaultModelCache(MavenSession mavenSession) {
+	RepositorySystemSession session
+	RepositoryCache cache
+
+	NotDefaultModelCache(MavenSession mavenSession) {
 		this.session = mavenSession.repositorySession
 		this.cache = mavenSession.repositorySession.cache
 	}
 
-	public Object get( String groupId, String artifactId, String version, String tag )
-	{
-		return cache.get( session, new Key( groupId, artifactId, version, tag ) );
+	Object get( String groupId, String artifactId, String version, String tag) {
+		return cache.get(session, new Key( groupId, artifactId, version, tag))
 	}
 
-	public void put( String groupId, String artifactId, String version, String tag, Object data )
-	{
-		cache.put( session, new Key( groupId, artifactId, version, tag ), data );
+	void put(String groupId, String artifactId, String version, String tag, Object data) {
+		cache.put(session, new Key(groupId, artifactId, version, tag), data)
 	}
 
-	static class Key
-	{
+	@CompileStatic(TypeCheckingMode.SKIP)
+	static class Key {
 
-		private final String groupId;
+		private final String groupId
+		private final String artifactId
+		private final String version
+		private final String tag
+		private final int hash
 
-		private final String artifactId;
+		Key(String groupId, String artifactId, String version, String tag) {
+			this.groupId = groupId
+			this.artifactId = artifactId
+			this.version = version
+			this.tag = tag
 
-		private final String version;
-
-		private final String tag;
-
-		private final int hash;
-
-		public Key( String groupId, String artifactId, String version, String tag )
-		{
-			this.groupId = groupId;
-			this.artifactId = artifactId;
-			this.version = version;
-			this.tag = tag;
-
-			int h = 17;
-			h = h * 31 + this.groupId.hashCode();
-			h = h * 31 + this.artifactId.hashCode();
-			h = h * 31 + this.version.hashCode();
-			h = h * 31 + this.tag.hashCode();
-			hash = h;
+			int h = 17
+			h = h * 31 + this.groupId.hashCode()
+			h = h * 31 + this.artifactId.hashCode()
+			h = h * 31 + this.version.hashCode()
+			h = h * 31 + this.tag.hashCode()
+			hash = h
 		}
 
 		@Override
-		public boolean equals( Object obj )
-		{
-			if ( this.is(obj) )
-			{
-				return true;
+		boolean equals(Object obj) {
+			if (this.is(obj)) {
+				return true
 			}
-			if ( null == obj || !getClass().equals( obj.getClass() ) )
-			{
-				return false;
+			if (null == obj || getClass() != obj.getClass()) {
+				return false
 			}
 
-			Key that = (Key) obj;
-			return artifactId.equals( that.artifactId ) && groupId.equals( that.groupId ) &&
-				version.equals( that.version ) && tag.equals( that.tag );
+			return artifactId == obj.artifactId && groupId == obj.groupId &&
+				version == obj.version && tag == obj.tag
 		}
 
 		@Override
-		public int hashCode()
-		{
-			return hash;
+		int hashCode() {
+			return hash
 		}
 
 	}

--- a/src/main/groovy/io/repaint/maven/tiles/TileModel.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TileModel.groovy
@@ -15,6 +15,7 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader
  *
  * @author: Richard Vowles - https://plus.google.com/+RichardVowles
  */
+@CompileStatic
 class TileModel {
 	Model model
 	List<String> tiles = []
@@ -80,6 +81,7 @@ class TileModel {
 
 	}
 
+	@CompileStatic(TypeCheckingMode.SKIP)
 	private static List<Plugin> rewritePluginExecutionIds(List<Plugin> plugins, Artifact artifact) {
 		plugins.each { plugin ->
 			if (plugin.executions) {

--- a/src/test/resources/filtering/pom.xml
+++ b/src/test/resources/filtering/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>io.repaint.tiles</groupId>
+	<artifactId>filtering-tile</artifactId>
+	<version>1.1-SNAPSHOT</version>
+	<packaging>tile</packaging>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>io.repaint.maven</groupId>
+				<artifactId>tiles-maven-plugin</artifactId>
+				<version>1.1-SNAPSHOT</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/test/resources/filtering/tile.xml
+++ b/src/test/resources/filtering/tile.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<tiles>
+		<tile>groupid:antrun1-tile:@project.version@</tile>
+	</tiles>
+</project>


### PR DESCRIPTION
Extracted from #84. Fixes #83.

Perform maven standard filtering (replacing properties) in tiles in the same reactor build before injecting