### PR TITLE
Allow a version property that evaluates as empty so it can be replaced later.

### DIFF
--- a/src/it/civersion-tiletest/dynamic/pom.xml
+++ b/src/it/civersion-tiletest/dynamic/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.test</groupId>
+    <artifactId>civersion-tiletest-dynamic</artifactId>
+    <version>${changelist}</version>
+
+    <packaging>pom</packaging>
+
+    <name>CI Friendly Build Version Maven Tiles Test - Dynamic Property</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.repaint.maven</groupId>
+                <artifactId>tiles-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <tiles>
+                        <tile>com.test:civersion-tiletest-tile3:1</tile>
+                    </tiles>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/civersion-tiletest/dynamic/test.properties
+++ b/src/it/civersion-tiletest/dynamic/test.properties
@@ -1,0 +1,1 @@
+changelist=0.1-SNAPSHOT

--- a/src/it/civersion-tiletest/pom.xml
+++ b/src/it/civersion-tiletest/pom.xml
@@ -29,8 +29,10 @@
         <module>parent1</module>
         <module>parent2</module>
         <module>parent3</module>
+        <module>dynamic</module>
         <module>tile-tile1</module>
         <module>tile-tile2</module>
+        <module>tile-tile3</module>
     </modules>
 
     <build>

--- a/src/it/civersion-tiletest/tile-tile3/pom.xml
+++ b/src/it/civersion-tiletest/tile-tile3/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.test</groupId>
+    <artifactId>civersion-tiletest-tile3</artifactId>
+    <version>1</version>
+
+    <packaging>tile</packaging>
+
+    <name>CI Friendly Build Version Maven Tiles Test - Tile3</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.repaint.maven</groupId>
+                <artifactId>tiles-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/civersion-tiletest/tile-tile3/tile.xml
+++ b/src/it/civersion-tiletest/tile-tile3/tile.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                  <execution>
+                    <phase>initialize</phase>
+                    <goals>
+                      <goal>read-project-properties</goal>
+                    </goals>
+                    <configuration>
+                      <files>
+                        <file>test.properties</file>
+                      </files>
+                    </configuration>
+                  </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/civersion-tiletest/verify.bsh
+++ b/src/it/civersion-tiletest/verify.bsh
@@ -28,6 +28,9 @@ if (!content.contains("[INFO] Mixed 'com.test:civersion-tiletest-tile2:1' with o
 if (!content.contains("<foo.bar.noparent>tile2</foo.bar.noparent>")) {
   throw new Exception("Tile not injected");
 }
+if (!content.contains("Injecting 1 tiles as intermediary parent artifacts for com.test:civersion-tiletest-dynamic")) {
+  throw new Exception("Tile not injected");
+}
 
 // check for pom->parent->tile inclusion
 if (!content.contains("[INFO] Mixed 'com.test:civersion-tiletest-parent2:1' with tile 'com.test:civersion-tiletest-tile2:1' as its new parent.")) {

--- a/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
@@ -407,11 +407,11 @@ public class TilesMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 			@Override
 			Model read(InputStream input, Map<String, ?> options) throws IOException, ModelParseException {
 				Model model = modelProcessor.read(input, options)
-
 				use(GavUtil) {
-					// evaluate the model version to deal with CI friendly build versions
+					// evaluate the model version to deal with CI friendly build versions.
+					// "0-SNAPSHOT" indicates an undefined property.
 					if (model.artifactId == project.artifactId && model.realGroupId == project.groupId
-						&& (evaluateString(model.realVersion) == project.version || evaluateString(model.realVersion) == null)
+						&& (evaluateString(model.realVersion) == project.version || evaluateString(model.realVersion) == "0-SNAPSHOT")
 						&& model.packaging == project.packaging) {
 						// we're at the first (project) level. Apply tiles here if no explicit parent is set
 						if (!applyBeforeParent) {

--- a/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
@@ -411,7 +411,8 @@ public class TilesMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 				use(GavUtil) {
 					// evaluate the model version to deal with CI friendly build versions
 					if (model.artifactId == project.artifactId && model.realGroupId == project.groupId
-						&& evaluateString(model.realVersion) == project.version && model.packaging == project.packaging) {
+						&& (evaluateString(model.realVersion) == project.version || evaluateString(model.realVersion) == null)
+						&& model.packaging == project.packaging) {
 						// we're at the first (project) level. Apply tiles here if no explicit parent is set
 						if (!applyBeforeParent) {
 							injectTilesIntoParentStructure(tiles, model, request)


### PR DESCRIPTION
This will allow tiles (and poms) that dynamically set the project version using a plugin, e.g. `properties-maven-plugin` or `git-commit-id-plugin`.

Fixes repaint-io/maven-tiles#95.