### PR TITLE
Fail tile validation if <build><extensions> is present.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 sudo: false
-script: bundle exec mvn clean install -Prun-its
+script: mvn clean install -Prun-its

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: java
 sudo: false
+script: bundle exec mvn clean install -Prun-its

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <groupId>io.repaint.maven</groupId>
   <artifactId>tiles-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>2.13-SNAPSHOT</version>
+  <version>2.14-SNAPSHOT</version>
   <name>Tiles Maven Plugin</name>
 
   <description>Provides composition support for Maven composition support for Maven</description>

--- a/src/main/groovy/io/repaint/maven/tiles/TileValidator.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TileValidator.groovy
@@ -117,6 +117,16 @@ class TileValidator {
 			validModel = null
 		}
 
+		if (model.build?.plugins) {
+			for (plugin in model.build.plugins) {
+				if (plugin.extensions) {
+					log.error("Tile has plugins with extensions and must not have")
+					validModel = null
+					break
+				}
+			}
+		}
+
 		return validModel
 	}
 }

--- a/src/main/groovy/io/repaint/maven/tiles/TileValidator.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TileValidator.groovy
@@ -112,6 +112,11 @@ class TileValidator {
 			validModel = null
 		}
 
+		if (model.build?.extensions) {
+			log.error("Tile has extensions and must not have")
+			validModel = null
+		}
+
 		return validModel
 	}
 }

--- a/src/test/groovy/io/repaint/maven/tiles/TileValidatorTest.groovy
+++ b/src/test/groovy/io/repaint/maven/tiles/TileValidatorTest.groovy
@@ -31,7 +31,7 @@ class TileValidatorTest {
 	public void testValidation() {
 		new TileValidator().loadModel(logger, new File("src/test/resources/bad-tile.xml"), "")
 
-		assert errors.size() == 9
+		assert errors.size() == 10
 		assert warnings.size() == 0
 		assert infos.size() == 0
 	}

--- a/src/test/groovy/io/repaint/maven/tiles/TileValidatorTest.groovy
+++ b/src/test/groovy/io/repaint/maven/tiles/TileValidatorTest.groovy
@@ -31,7 +31,7 @@ class TileValidatorTest {
 	public void testValidation() {
 		new TileValidator().loadModel(logger, new File("src/test/resources/bad-tile.xml"), "")
 
-		assert errors.size() == 8
+		assert errors.size() == 9
 		assert warnings.size() == 0
 		assert infos.size() == 0
 	}

--- a/src/test/resources/bad-tile.xml
+++ b/src/test/resources/bad-tile.xml
@@ -51,14 +51,14 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>group</groupId>
-					<artifactId>artifact</artifactId>
-					<version>version</version>
-					<extensions>true</extensions>
-				</plugin>
-			</plugins>
+		<plugins>
+			<plugin>
+				<groupId>group</groupId>
+				<artifactId>artifact</artifactId>
+				<version>version</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
 		<extensions>
 			<extension>
 				<groupId>group</groupId>

--- a/src/test/resources/bad-tile.xml
+++ b/src/test/resources/bad-tile.xml
@@ -51,6 +51,14 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>group</groupId>
+					<artifactId>artifact</artifactId>
+					<version>version</version>
+					<extensions>true</extensions>
+				</plugin>
+			</plugins>
 		<extensions>
 			<extension>
 				<groupId>group</groupId>

--- a/src/test/resources/bad-tile.xml
+++ b/src/test/resources/bad-tile.xml
@@ -51,5 +51,13 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<extensions>
+			<extension>
+				<groupId>group</groupId>
+				<artifactId>artifact</artifactId>
+				<version>version</version>
+			</extension>
+		</extensions>
 	</build>
+
 </project>


### PR DESCRIPTION
Fixes repaint-io/maven-tiles#94.