### PR TITLE
 ENH: Support explicit merging of tiles execution configuration

### DIFF
--- a/src/test/resources/test-merge-tile/kapt-dinject-tile.xml
+++ b/src/test/resources/test-merge-tile/kapt-dinject-tile.xml
@@ -7,7 +7,7 @@
 
   <properties>
     <dinject-generator.version>1.8</dinject-generator.version>
-    <tile-merge-configuration>true</tile-merge-configuration>
+    <tile-merge-source>true</tile-merge-source>
   </properties>
 
   <build>
@@ -31,7 +31,6 @@
               </annotationProcessorPaths>
             </configuration>
           </execution>
-         
         </executions>
       </plugin>
 

--- a/src/test/resources/test-merge-tile/kapt-dinject-tile.xml
+++ b/src/test/resources/test-merge-tile/kapt-dinject-tile.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+
+  <description>
+    Add KAPT annotation processor to generate DInject Dependency injection (as java source code).
+  </description>
+
+  <properties>
+    <dinject-generator.version>1.8</dinject-generator.version>
+    <tile-merge-configuration>true</tile-merge-configuration>
+  </properties>
+
+  <build>
+
+    <plugins>
+
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+
+        <executions>
+          <execution>
+            <id>kapt</id>
+            <configuration tiles-keep-id="true">
+              <annotationProcessorPaths>
+                <annotationProcessorPath>
+                  <groupId>io.dinject</groupId>
+                  <artifactId>dinject-generator</artifactId>
+                  <version>${dinject-generator.version}</version>
+                </annotationProcessorPath>
+              </annotationProcessorPaths>
+            </configuration>
+          </execution>
+         
+        </executions>
+      </plugin>
+
+    </plugins>
+
+  </build>
+
+</project>

--- a/src/test/resources/test-merge-tile/kapt-javalin-tile.xml
+++ b/src/test/resources/test-merge-tile/kapt-javalin-tile.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+
+  <description>
+    Add KAPT annotation processor to generate javalin controllers (as java source code).
+  </description>
+
+  <properties>
+    <tile-merge-configuration>true</tile-merge-configuration>
+  </properties>
+
+  <build>
+    <plugins>
+
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+
+        <executions>
+          <execution>
+            <id>kapt</id>
+            <configuration tiles-keep-id="true">
+              <annotationProcessorPaths>
+                <annotationProcessorPath>
+                  <!-- Generate web route adapters for Javalin Controllers -->
+                  <groupId>io.dinject</groupId>
+                  <artifactId>javalin-generator</artifactId>
+                  <version>1.6</version>
+                </annotationProcessorPath>
+              </annotationProcessorPaths>
+            </configuration>
+          </execution>
+
+        </executions>
+      </plugin>
+
+    </plugins>
+
+  </build>
+
+</project>

--- a/src/test/resources/test-merge-tile/kapt-javalin-tile.xml
+++ b/src/test/resources/test-merge-tile/kapt-javalin-tile.xml
@@ -6,7 +6,7 @@
   </description>
 
   <properties>
-    <tile-merge-configuration>true</tile-merge-configuration>
+    <tile-merge-source>true</tile-merge-source>
   </properties>
 
   <build>

--- a/src/test/resources/test-merge-tile/kapt-tile.xml
+++ b/src/test/resources/test-merge-tile/kapt-tile.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+
+  <description>
+    Kotlin compiler with KAPT annotation processing support.
+  </description>
+
+  <properties>
+    <tile-merge-target>true</tile-merge-target>
+    <java.version>1.8</java.version>
+    <kotlin.version>1.3.31</kotlin.version>
+    <kotlin.apiVersion>1.3</kotlin.apiVersion>
+    <kotlin.jvmTarget>1.8</kotlin.jvmTarget>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <sourceDirectory>src/main/kotlin</sourceDirectory>
+    <testSourceDirectory>src/test/kotlin</testSourceDirectory>
+
+    <plugins>
+
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
+        <configuration>
+          <apiVersion>${kotlin.apiVersion}</apiVersion>
+          <jvmTarget>${kotlin.jvmTarget}</jvmTarget>
+        </configuration>
+
+        <executions>
+          <execution>
+            <id>kapt</id>
+            <goals>
+              <goal>kapt</goal>
+            </goals>
+            <configuration tiles-keep-id="true" tiles-append="annotationProcessorPaths">
+              <sourceDirs>
+                <sourceDir>src/main/kotlin</sourceDir>
+                <sourceDir>src/main/java</sourceDir>
+              </sourceDirs>
+              <annotationProcessorPaths>
+
+                <!-- annotation processors added here -->  
+ 
+              </annotationProcessorPaths>         
+            </configuration>
+          </execution>
+
+          <execution>
+            <configuration tiles-keep-id="true"/>
+            <id>compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <configuration tiles-keep-id="true"/>
+            <id>test-compile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.0</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+        <executions>
+          <!-- Replacing default-compile as it is treated specially by maven -->
+          <execution>
+            <id>default-compile</id>
+            <phase>none</phase>
+            <configuration tiles-keep-id="true"/>
+          </execution>
+          <!-- Replacing default-testCompile as it is treated specially by maven -->
+          <execution>
+            <id>default-testCompile</id>
+            <phase>none</phase>
+            <configuration tiles-keep-id="true"/>
+          </execution>
+          <execution>
+            <configuration tiles-keep-id="true"/>
+            <id>java-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <configuration tiles-keep-id="true"/>
+            <id>java-test-compile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+
+  </build>
+
+</project>

--- a/src/test/resources/test-merge-tile/pom.xml
+++ b/src/test/resources/test-merge-tile/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>io.repaint.tiles</groupId>
+	<artifactId>test-tile-merge</artifactId>
+	<version>1.1-SNAPSHOT</version>
+	<packaging>tile</packaging>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>io.repaint.maven</groupId>
+				<artifactId>tiles-maven-plugin</artifactId>
+				<version>1.1-SNAPSHOT</version>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
Supports the merging of plugin execution configuration from tiles into a 'main' tile.

The motivation is for Kotlin KAPT where the annotation processors are configured as part of the plugin execution configuration. To use this we have:
- A 'main' tile that expects execution configuration to be merged into it from other tiles (e.g. kapt-tile.xml in tests)
- Other tiles that expect to have configuration that is merged into the main tile (e.g. kapt-dinject-tile.xml and kapt-javalin-tile.xml in tests).  These tiles are have their content merged into the 'main' target tile and then are effectively thrown away.

An example of the usage of these tiles would be:

```xml
            <plugin>
                <groupId>io.repaint.maven</groupId>
                <artifactId>tiles-maven-plugin</artifactId>
                <version>2.16-SNAPSHOT</version>
                <extensions>true</extensions>
                <configuration>
                    <tiles>

                        <!-- 'main' kapt annotation processor tile -->
                        <tile>io.avaje.kotlin:kapt:1.1-SNAPSHOT</tile>

                        <!-- + 1 tile per annotation processor -->
                        <tile>io.avaje.kotlin:kapt-javalin:1.1-SNAPSHOT</tile>
                        <tile>io.avaje.kotlin:kapt-dinject:1.1-SNAPSHOT</tile>

                        <!-- other tiles -->
                        <tile>org.avaje.tile:lib-classpath:1.1</tile>
                    </tiles>
                </configuration>
            </plugin>
``` 