### PR TITLE
Undefined properties evaluate to 0-SNAPSHOT or null in different conditions

### DIFF
--- a/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
@@ -423,7 +423,7 @@ public class TilesMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 					// evaluate the model version to deal with CI friendly build versions.
 					// "0-SNAPSHOT" indicates an undefined property.
 					if (model.artifactId == project.artifactId && model.realGroupId == project.groupId
-						&& (evaluateString(model.realVersion) == project.version || evaluateString(model.realVersion) == "0-SNAPSHOT")
+						&& (evaluateString(model.realVersion) == project.version || evaluateString(model.realVersion) == "0-SNAPSHOT" || evaluateString(model.realVersion) == null)
 						&& model.packaging == project.packaging) {
 						// we're at the first (project) level. Apply tiles here if no explicit parent is set
 						if (!applyBeforeParent) {


### PR DESCRIPTION
Following up on #97, I'm seeing `null` values again. Can't identify the specific conditions this happens in, but it does so it's probably better to allow either.