### PR TITLE
Plugin Execution & Property Ordering Tests

### DIFF
--- a/src/it/order-tests/pom.xml
+++ b/src/it/order-tests/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.repaint.maven</groupId>
+    <artifactId>tile-order-test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>Maven Tiles Order Test</name>
+
+    <modules>
+        <module>tileA</module>
+        <module>tileB</module>
+        <module>tileC</module>
+        <module>tileD</module>
+        <module>projectA</module>
+    </modules>
+</project>

--- a/src/it/order-tests/projectA/pom.xml
+++ b/src/it/order-tests/projectA/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.repaint.maven</groupId>
+    <artifactId>projectA</artifactId>
+    <version>1</version>
+    <packaging>pom</packaging>
+
+    <name>Maven Tiles Order Test</name>
+
+    <properties>
+        <propertyAP>pom</propertyAP>
+        <propertyBP>pom</propertyBP>
+        <propertyCP>pom</propertyCP>
+        <propertyABP>pom</propertyABP>
+        <propertyACP>pom</propertyACP>
+        <propertyBCP>pom</propertyBCP>
+        <propertyABCP>pom</propertyABCP>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.repaint.maven</groupId>
+                <artifactId>tiles-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <tiles>
+                        <tile>io.repaint.maven:tileB:1</tile>
+                        <tile>io.repaint.maven:tileC:1</tile>
+                        <tile>io.repaint.maven:tileD:1</tile>
+                    </tiles>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.soebes.maven.plugins</groupId>
+                <artifactId>echo-maven-plugin</artifactId>
+                <version>0.4.0</version>
+                <executions>
+                    <execution>
+                        <id>properties</id>
+                        <phase>validate</phase>
+                        <goals><goal>echo</goal></goals>
+                        <configuration>
+                            <echos>
+                                <echo>propertyA: ${propertyA}</echo>
+                                <echo>propertyB: ${propertyB}</echo>
+                                <echo>propertyC: ${propertyC}</echo>
+                                <echo>propertyAB: ${propertyAB}</echo>
+                                <echo>propertyAC: ${propertyAC}</echo>
+                                <echo>propertyBC: ${propertyBC}</echo>
+                                <echo>propertyABC: ${propertyABC}</echo>
+                                <echo>proj propertyA: ${propertyAP}</echo>
+                                <echo>proj propertyB: ${propertyBP}</echo>
+                                <echo>proj propertyC: ${propertyCP}</echo>
+                                <echo>proj propertyAB: ${propertyABP}</echo>
+                                <echo>proj propertyAC: ${propertyACP}</echo>
+                                <echo>proj propertyBC: ${propertyBCP}</echo>
+                                <echo>proj propertyABC: ${propertyABCP}</echo>
+                            </echos>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/order-tests/tileA/pom.xml
+++ b/src/it/order-tests/tileA/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.repaint.maven</groupId>
+    <artifactId>tileA</artifactId>
+    <version>1</version>
+    <packaging>tile</packaging>
+
+    <name>Maven Tiles Order Test - TileA</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.repaint.maven</groupId>
+                <artifactId>tiles-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/it/order-tests/tileA/tile.xml
+++ b/src/it/order-tests/tileA/tile.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.soebes.maven.plugins</groupId>
+                <artifactId>echo-maven-plugin</artifactId>
+                <version>0.4.0</version>
+                <executions>
+                    <execution>
+                        <id>E1</id>
+                        <phase>initialize</phase>
+                        <goals><goal>echo</goal></goals>
+                        <configuration>
+                            <echos>
+                                <echo>Tile A (E1)</echo>
+                            </echos>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>E2</id>
+                        <phase>initialize</phase>
+                        <goals><goal>echo</goal></goals>
+                        <configuration>
+                            <tiles-keep-id>true</tiles-keep-id>
+                            <echos>
+                                <echo>Tile A (E2)</echo>
+                            </echos>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tileA</id>
+                        <phase>initialize</phase>
+                        <goals><goal>echo</goal></goals>
+                        <configuration>
+                            <echos>
+                                <echo>Tile A</echo>
+                            </echos>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>default-props</id>
+            <activation>
+                <property>
+                    <name>!prop-does-not-exist</name>
+                </property>
+            </activation>
+            <properties>
+                <propertyA>tileA</propertyA>
+                <propertyAB>tileA</propertyAB>
+                <propertyAC>tileA</propertyAC>
+                <propertyABC>tileA</propertyABC>
+                <propertyAP>tileA</propertyAP>
+                <propertyABP>tileA</propertyABP>
+                <propertyACP>tileA</propertyACP>
+                <propertyABCP>tileA</propertyABCP>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/src/it/order-tests/tileB/pom.xml
+++ b/src/it/order-tests/tileB/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.repaint.maven</groupId>
+    <artifactId>tileB</artifactId>
+    <version>1</version>
+    <packaging>tile</packaging>
+
+    <name>Maven Tiles Order Test - TileB</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.repaint.maven</groupId>
+                <artifactId>tiles-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/it/order-tests/tileB/tile.xml
+++ b/src/it/order-tests/tileB/tile.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.soebes.maven.plugins</groupId>
+                <artifactId>echo-maven-plugin</artifactId>
+                <version>0.4.0</version>
+                <executions>
+                    <execution>
+                        <id>E1</id>
+                        <phase>initialize</phase>
+                        <goals><goal>echo</goal></goals>
+                        <configuration>
+                            <echos>
+                                <echo>Tile B (E1)</echo>
+                            </echos>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>E2</id>
+                        <phase>initialize</phase>
+                        <goals><goal>echo</goal></goals>
+                        <configuration>
+                            <tiles-keep-id>true</tiles-keep-id>
+                            <echos>
+                                <echo>Tile B (E2)</echo>
+                            </echos>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tileB</id>
+                        <phase>initialize</phase>
+                        <goals><goal>echo</goal></goals>
+                        <configuration>
+                            <echos>
+                                <echo>Tile B</echo>
+                            </echos>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>default-props</id>
+            <activation>
+                <property>
+                    <name>!prop-does-not-exist</name>
+                </property>
+            </activation>
+            <properties>
+                <propertyB>tileB</propertyB>
+                <propertyAB>tileB</propertyAB>
+                <propertyBC>tileB</propertyBC>
+                <propertyABC>tileB</propertyABC>
+                <propertyBP>tileB</propertyBP>
+                <propertyABP>tileB</propertyABP>
+                <propertyBCP>tileB</propertyBCP>
+                <propertyABCP>tileB</propertyABCP>
+            </properties>
+        </profile>
+    </profiles>
+
+</project>

--- a/src/it/order-tests/tileC/pom.xml
+++ b/src/it/order-tests/tileC/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.repaint.maven</groupId>
+    <artifactId>tileC</artifactId>
+    <version>1</version>
+    <packaging>tile</packaging>
+
+    <name>Maven Tiles Order Test - TileC</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.repaint.maven</groupId>
+                <artifactId>tiles-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/order-tests/tileC/tile.xml
+++ b/src/it/order-tests/tileC/tile.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.soebes.maven.plugins</groupId>
+                <artifactId>echo-maven-plugin</artifactId>
+                <version>0.4.0</version>
+                <executions>
+                    <execution>
+                        <id>E1</id>
+                        <phase>initialize</phase>
+                        <goals><goal>echo</goal></goals>
+                        <configuration>
+                            <echos>
+                                <echo>Tile C (E1)</echo>
+                            </echos>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>E2</id>
+                        <phase>initialize</phase>
+                        <goals><goal>echo</goal></goals>
+                        <configuration>
+                            <tiles-keep-id>true</tiles-keep-id>
+                            <echos>
+                                <echo>Tile C (E2)</echo>
+                            </echos>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tileB</id>
+                        <phase>initialize</phase>
+                        <goals><goal>echo</goal></goals>
+                        <configuration>
+                            <echos>
+                                <echo>Tile C</echo>
+                            </echos>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>default-props</id>
+            <activation>
+                <property>
+                    <name>!prop-does-not-exist</name>
+                </property>
+            </activation>
+            <properties>
+                <propertyC>tileC</propertyC>
+                <propertyAC>tileC</propertyAC>
+                <propertyBC>tileC</propertyBC>
+                <propertyABC>tileC</propertyABC>
+                <propertyCP>tileC</propertyCP>
+                <propertyACP>tileC</propertyACP>
+                <propertyBCP>tileC</propertyBCP>
+                <propertyABCP>tileC</propertyABCP>
+            </properties>
+        </profile>
+    </profiles>
+
+    <tiles>
+        <tile>io.repaint.maven:tileA:1</tile>
+    </tiles>
+
+</project>

--- a/src/it/order-tests/tileD/pom.xml
+++ b/src/it/order-tests/tileD/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.repaint.maven</groupId>
+    <artifactId>tileD</artifactId>
+    <version>1</version>
+    <packaging>tile</packaging>
+
+    <name>Maven Tiles Order Test - TileD</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.repaint.maven</groupId>
+                <artifactId>tiles-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/order-tests/tileD/tile.xml
+++ b/src/it/order-tests/tileD/tile.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.soebes.maven.plugins</groupId>
+                <artifactId>echo-maven-plugin</artifactId>
+                <version>0.4.0</version>
+                <executions>
+                    <execution>
+                        <id>E1</id>
+                        <phase>initialize</phase>
+                        <goals><goal>echo</goal></goals>
+                        <configuration>
+                            <echos>
+                                <echo>Tile D (E1)</echo>
+                            </echos>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>E2</id>
+                        <phase>initialize</phase>
+                        <goals><goal>echo</goal></goals>
+                        <configuration>
+                            <tiles-keep-id>true</tiles-keep-id>
+                            <echos>
+                                <echo>Tile D (E2)</echo>
+                            </echos>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tileB</id>
+                        <phase>initialize</phase>
+                        <goals><goal>echo</goal></goals>
+                        <configuration>
+                            <echos>
+                                <echo>Tile D</echo>
+                            </echos>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/src/it/order-tests/verify.bsh
+++ b/src/it/order-tests/verify.bsh
@@ -1,0 +1,76 @@
+import java.io.*;
+import java.util.*;
+
+File file = new File( basedir, "build.log" );
+if ( !file.isFile() ) {
+    throw new FileNotFoundException( "Could not find build log: " + file );
+}
+
+String content = new Scanner(file).useDelimiter("\\Z").next();
+
+// tileX should win
+if (!content.contains("[INFO] propertyA: tileA"))
+  throw new Exception("tileA is expected to win at defining propertyA");
+if (!content.contains("[INFO] propertyB: tileB"))
+  throw new Exception("tileB is expected to win at defining propertyB");
+if (!content.contains("[INFO] propertyC: tileC"))
+  throw new Exception("tileC is expected to win at defining propertyC");
+if (!content.contains("[INFO] propertyAB: tileB"))
+  throw new Exception("tileB is expected to win at defining propertyAB");
+if (!content.contains("[INFO] propertyAC: tileC"))
+  throw new Exception("tileC is expected to win at defining propertyAC");
+if (!content.contains("[INFO] propertyBC: tileB"))
+  throw new Exception("tileB is expected to win at defining propertyBC");
+if (!content.contains("[INFO] propertyABC: tileB"))
+  throw new Exception("tileB is expected to win at defining propertyABC");
+
+// pom should win
+if (!content.contains("[INFO] proj propertyA: pom"))
+  throw new Exception("The pom is expected to win at defining propertyAP");
+if (!content.contains("[INFO] proj propertyB: pom"))
+  throw new Exception("The pom is expected to win at defining propertyBP");
+if (!content.contains("[INFO] proj propertyC: pom"))
+  throw new Exception("The pom is expected to win at defining propertyCP");
+if (!content.contains("[INFO] proj propertyAB: pom"))
+  throw new Exception("The pom is expected to win at defining propertyABP");
+if (!content.contains("[INFO] proj propertyAC: pom"))
+  throw new Exception("The pom is expected to win at defining propertyACP");
+if (!content.contains("[INFO] proj propertyBC: pom"))
+  throw new Exception("The pom is expected to win at defining propertyBCP");
+if (!content.contains("[INFO] proj propertyABC: pom"))
+  throw new Exception("The pom is expected to win at defining propertyABCP");
+
+// plugin executions that should be shadowed
+if (content.contains("[INFO] Tile A (E2)"))
+  throw new Exception("The tileA E2 execution should have been shadowed");
+if (content.contains("[INFO] Tile C (E2)"))
+  throw new Exception("The tileC E2 execution should have been shadowed");
+if (content.contains("[INFO] Tile D (E2)"))
+  throw new Exception("The tileD E2 execution should have been shadowed");
+
+List indexes = new LinkedList();
+indexes.add(content.indexOf("[INFO] Tile A (E1)"));
+indexes.add(content.indexOf("[INFO] Tile B (E2)"));
+indexes.add(content.indexOf("[INFO] Tile A"));
+indexes.add(content.indexOf("[INFO] Tile D (E1)"));
+indexes.add(content.indexOf("[INFO] Tile D"));
+indexes.add(content.indexOf("[INFO] Tile C (E1)"));
+indexes.add(content.indexOf("[INFO] Tile C"));
+indexes.add(content.indexOf("[INFO] Tile B (E1)"));
+indexes.add(content.indexOf("[INFO] Tile B"));
+
+// how I think it should happen
+//indexes.add(content.indexOf("[INFO] Tile D (E1)"));
+//indexes.add(content.indexOf("[INFO] Tile D"));
+//indexes.add(content.indexOf("[INFO] Tile A (E1)"));
+//indexes.add(content.indexOf("[INFO] Tile B (E2)"));
+//indexes.add(content.indexOf("[INFO] Tile A"));
+//indexes.add(content.indexOf("[INFO] Tile C (E1)"));
+//indexes.add(content.indexOf("[INFO] Tile C"));
+//indexes.add(content.indexOf("[INFO] Tile B (E1)"));
+//indexes.add(content.indexOf("[INFO] Tile B"));
+
+Integer lastindex = -1;
+for (Integer index : indexes)
+  if (lastindex > index)
+    throw new Exception("The tile execution order is not in the proper order, starting with the " + index + " output");


### PR DESCRIPTION
This test does two things: see who wins property declarations and check the order of plugin executions.  It does this across 3 child tiles and 1 grandchild tile (of the middle child).

tileB, tileC, and tileD are the children.  tileA is a child of tileC.  projectA is the one using these tiles.

The `verify.bsh` has the current case enabled.  It has what I think it should be commented out.