### PR TITLE
Update contribution guidelines and README

### DIFF
--- a/.github/workflows/java16.yml
+++ b/.github/workflows/java16.yml
@@ -1,6 +1,10 @@
 name: Integration Tests on Java 16
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/java8.yml
+++ b/.github/workflows/java8.yml
@@ -1,6 +1,10 @@
 name: Integration Tests on Java 8
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ target
 !.gitignore
 !.gitattributes
 !.gitkeep
+
+# and iDEA
+*.iml

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -9,9 +9,7 @@ easy and effective for everyone involved.
 
 The https://github.com/repaint-io/maven-tiles/issues[issue tracker] is
 the preferred channel for reporting all bugs or feature requests for the
-plugin. Pull requests are accepted but will be managed via
-https://review.gerrithub.io/#/q/project:repaint-io/maven-tiles[GerritHub.io] ( see below )
-but please respect the following restrictions:
+plugin.
 
 * Please **do not** use the issue tracker for personal support requests.
 
@@ -21,73 +19,15 @@ but please respect the following restrictions:
 * Please **do not** derail or troll issues. Keep the discussion on topic and
   respect the opinions of others.
 
-=== GerritHub.io
+=== Submitting a patch
 
-Rather than using Github's Pull Request model, the _tiles-maven-plugin_ is using the
-https://code.google.com/p/gerrit/[Gerrit] code review tool via the public http://gerrithub.io[GerritHub.io]
-service for pre-merge code review.
+Pull requests are accepted and managed via Github but please respect the following restrictions:
 
-Github pull requests SHOULD be automatically pulled into GerritHub as reviews, and any
-updated changes will be expected to be pushed/managed via GerritHub.io, however direct review submissions
-via GerritHub.io are preferred.
-
-==== Submission via GerritHub
-
-Clone the repository::
-[source,shell]
-----
-git clone https://review.gerrithub.io/repaint-io/maven-tiles
-----
-
-Install Gerrit Commit Message Hook::
-[source,shell]
-----    
-curl -Lo .git/hooks/commit-msg http://review.gerrithub.io/tools/hooks/commit-msg
-----
-
-Make changes and submit::
-[source,shell]
-----
-git add ...
-git commit ...
-git push origin HEAD:refs/for/master
-----
-
-Update changes and resubmit::
-[source,shell]
-----
-git add ...
-git commit --amend ...
-git push origin HEAD:refs/for/master
-----
-
-**IMPORTANT**: By submitting a patch, you agree to allow the project owners to
+NOTE: **IMPORTANT**: By submitting a patch, you agree to allow the project owners to
 license your work under the terms of the Apache 2.0 License.
 
-If you've already forked the Maven Tiles Github repository, you can configure
-your existing clone to support GerritHub submission as follows:
+Please do not over-commit, make each commit meaningful and consider squashing your commits. We may
+ask you to do that before considering merging your commit. Our ideal is one commit per
+issue if possible.
 
-Configure an existing clone::
-[source,shell]
-----
-git remote add gerrithub https://review.gerrithub.io/repaint-io/maven-tiles
-----
-Install Gerrit Commit Message Hook::
-[source,shell]
-----
-curl -Lo .git/hooks/commit-msg http://review.gerrithub.io/tools/hooks/commit-msg
-----
-Make changes and submit::
-[source,shell]
-----
-git add ...
-git commit ...
-git push gerrithub HEAD:refs/for/master
-----
-Update changes and resubmit::
-[source,shell]
-----
-git add ...
-git commit --amend ...
-git push gerrithub HEAD:refs/for/master
-----
+

--- a/README.adoc
+++ b/README.adoc
@@ -129,7 +129,8 @@ section when processing and use it directly.
 
 Execution ids within tiles are prepended with the gav parameters of the tile that included the execution, for easier
 debugging / tracing. If this is not desired, adding a configuration attribute `tiles-keep-id="true"` or entry
-`<tiles-keep-id>true<tiles-keep-id>` will keep the original id.
+`<tiles-keep-id>true<tiles-keep-id>` will keep the original id. If you are using the _Kotlin Maven plugin_, you will
+need to use this or it will not work.
 
 [source,xml,indent=0]
 .tile.xml
@@ -255,9 +256,8 @@ As a use case, an example of how it will be used for my projects.
 
 Richard will have:
 
-- *java6-tile* - for those projects that have to remain Java 6
-- *java7-tile* - for those projects that haven't yet moved to Java 8
 - *java8-tile* - for those projects that are on Java 8
+- *java11-tile* - for those projects that are on Java LTS (11)
 - *groovy-tile* - which defines the build structure necessary to build a Groovy project, including GMavenPlus, GroovyDoc
 and Source plugins
 - *java-tile* - for Java only projects which include all the Javadoc and Source plugins


### PR DESCRIPTION
Dropping support for Gerrit as our PR mechanism
as it is yet another barrier to contribution.
Updated the readme to tag the extension ids for
Kotlin as that is a major example.