### PR TITLE
Cannot invoke method hashCode() on null object in complex CI Friendly Project #128

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <groupId>io.repaint.maven</groupId>
   <artifactId>tiles-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>2.25-SNAPSHOT</version>
+  <version>2.25.1</version>
   <name>Tiles Maven Plugin</name>
 
   <description>Provides composition support for Maven composition support for Maven</description>
@@ -60,17 +60,16 @@
     <tag>HEAD</tag>
   </scm>
 
+
   <distributionManagement>
-    <repository>
-      <id>sonatype-staging</id>
-      <name>oss.sonatype.org Staging Repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
     <snapshotRepository>
-      <id>sonatype-snapshots</id>
-      <name>oss.sonatype.org Snapshot Repository</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <id>snapshots</id>
+      <url>http://maven-serv1.innovas.de:8081/nexus/content/repositories/snapshots/</url>
     </snapshotRepository>
+    <repository>
+      <id>internal</id>
+      <url>http://maven-serv1.innovas.de:8081/nexus/content/repositories/releases/</url>
+    </repository>
   </distributionManagement>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <groupId>io.repaint.maven</groupId>
   <artifactId>tiles-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>2.25.1</version>
+  <version>2.25-SNAPSHOT</version>
   <name>Tiles Maven Plugin</name>
 
   <description>Provides composition support for Maven composition support for Maven</description>
@@ -60,16 +60,17 @@
     <tag>HEAD</tag>
   </scm>
 
-
   <distributionManagement>
-    <snapshotRepository>
-      <id>snapshots</id>
-      <url>http://maven-serv1.innovas.de:8081/nexus/content/repositories/snapshots/</url>
-    </snapshotRepository>
     <repository>
-      <id>internal</id>
-      <url>http://maven-serv1.innovas.de:8081/nexus/content/repositories/releases/</url>
+      <id>sonatype-staging</id>
+      <name>oss.sonatype.org Staging Repository</name>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
+    <snapshotRepository>
+      <id>sonatype-snapshots</id>
+      <name>oss.sonatype.org Snapshot Repository</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </snapshotRepository>
   </distributionManagement>
 
   <dependencies>

--- a/src/it/civersion-tiletest-workspace-pom/pom.xml
+++ b/src/it/civersion-tiletest-workspace-pom/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.test</groupId>
+  <artifactId>civersion-workspace-test</artifactId>
+  <version>SNAPSHOT</version>
+
+  <packaging>pom</packaging>
+
+  <name>CI Friendly Build Version Maven Tiles Test</name>
+
+
+  <modules>
+    <module>tile-tile1</module>
+    <module>projectBParent</module>
+    <module>projectAParent</module>
+    
+  </modules>
+
+</project>

--- a/src/it/civersion-tiletest-workspace-pom/projectAParent/pom.xml
+++ b/src/it/civersion-tiletest-workspace-pom/projectAParent/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.test</groupId>
+  <artifactId>civersion-tiletest-projectAParent</artifactId>
+  <version>${revision}</version>
+
+  <packaging>pom</packaging>
+
+  <properties>
+    <revision>SNAPSHOT-1</revision>
+  </properties>
+
+  <name>CI Friendly Build Version Maven Tiles Test - ProjectAParent</name>
+
+  <modules>
+    <module>projectA</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <configuration>
+          <updatePomFile>true</updatePomFile>
+          <flattenMode>resolveCiFriendliesOnly</flattenMode>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/civersion-tiletest-workspace-pom/projectAParent/projectA/pom.xml
+++ b/src/it/civersion-tiletest-workspace-pom/projectAParent/projectA/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+
+  <parent>
+    <groupId>com.test</groupId>
+    <artifactId>civersion-tiletest-projectAParent</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <groupId>com.test</groupId>
+  <artifactId>civersion-tiletest-projectA</artifactId>
+
+  <packaging>jar</packaging>
+
+  <name>CI Friendly Build Version Maven Tiles Test - ProjectA</name>
+
+  <dependencies>
+    <dependency>
+      <artifactId>civersion-tiletest-projectB</artifactId>
+      <groupId>com.test</groupId>
+      <version>SNAPSHOT-1</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.repaint.maven</groupId>
+        <artifactId>tiles-maven-plugin</artifactId>
+        <version>2.24</version>
+        <configuration>
+          <tiles>
+            <tile>com.test:civersion-tiletest-workspace-tile1:1</tile>
+          </tiles>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+</project>

--- a/src/it/civersion-tiletest-workspace-pom/projectBParent/pom.xml
+++ b/src/it/civersion-tiletest-workspace-pom/projectBParent/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.test</groupId>
+  <artifactId>civersion-tiletest-projectBParent</artifactId>
+  <version>${revision}</version>
+
+  <packaging>pom</packaging>
+
+  <properties>
+    <revision>SNAPSHOT-1</revision>
+  </properties>
+
+  <name>CI Friendly Build Version Maven Tiles Test - ProjectBParent</name>
+
+  <modules>
+    <module>projectB</module>
+  </modules>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <configuration>
+          <updatePomFile>true</updatePomFile>
+          <flattenMode>resolveCiFriendliesOnly</flattenMode>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/civersion-tiletest-workspace-pom/projectBParent/projectB/pom.xml
+++ b/src/it/civersion-tiletest-workspace-pom/projectBParent/projectB/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.test</groupId>
+    <artifactId>civersion-tiletest-projectBParent</artifactId>
+    <version>${revision}</version>
+  </parent>
+  
+  <groupId>com.test</groupId>
+  <artifactId>civersion-tiletest-projectB</artifactId>
+  
+
+  <packaging>jar</packaging>
+
+  <name>CI Friendly Build Version Maven Tiles Test - ProjectB</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.repaint.maven</groupId>
+        <artifactId>tiles-maven-plugin</artifactId>
+        <version>2.24</version>
+        <configuration>
+          <tiles>
+            <tile>com.test:civersion-tiletest-workspace-tile1:1</tile>
+          </tiles>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/civersion-tiletest-workspace-pom/readme.md
+++ b/src/it/civersion-tiletest-workspace-pom/readme.md
@@ -1,0 +1,86 @@
+Setup is:
+ProjectA is built by ProjectAParent
+ProjectB is built by ProjectBParent
+Both use ${revision]
+
+
+ProjectA has a dependency to ProjectB
+
+We use a "workspace pom" for Eclipse the references these modules.
+
+
+To reproduce the error:
+ run mvn install on pom.xml
+
+
+
+The error log is:
+
+[INFO] Scanning for projects...
+[WARNING] 
+[WARNING] Some problems were encountered while building the effective model for com.test:civersion-workspace-test:pom:SNAPSHOT
+[WARNING] 'version' uses an unsupported snapshot version format, should be '*-SNAPSHOT' instead. @ line 8, column 12
+[WARNING] 
+[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
+[WARNING] 
+[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
+[WARNING] 
+[INFO] --- tiles-maven-plugin: Injecting 1 tiles as intermediary parent artifacts for com.test:civersion-tiletest-projectB...
+[INFO] Mixed 'com.test:civersion-tiletest-projectB:null' with tile 'com.test:civersion-tiletest-workspace-tile1:1' as its new parent.
+[INFO] Explicitly set version to 'null' from original parent 'com.test:civersion-tiletest-projectBParent:null'.
+[INFO] Mixed 'com.test:civersion-tiletest-workspace-tile1:1' with original parent 'com.test:civersion-tiletest-projectBParent:null' as its new top level parent.
+[INFO] 
+[ERROR] Internal error: java.lang.NullPointerException: Cannot invoke method hashCode() on null object -> [Help 1]
+org.apache.maven.InternalErrorException: Internal error: java.lang.NullPointerException: Cannot invoke method hashCode() on null object
+    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:120)
+    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:972)
+    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
+    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
+    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
+    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
+    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
+    at java.lang.reflect.Method.invoke (Method.java:498)
+    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
+    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
+    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
+    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
+Caused by: java.lang.NullPointerException: Cannot invoke method hashCode() on null object
+    at org.codehaus.groovy.runtime.NullObject.hashCode (NullObject.java:174)
+    at org.codehaus.groovy.runtime.NullObject$hashCode.call (Unknown Source)
+    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall (CallSiteArray.java:47)
+    at org.codehaus.groovy.runtime.callsite.NullCallSite.call (NullCallSite.java:34)
+    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall (CallSiteArray.java:47)
+    at java_lang_String$hashCode.call (Unknown Source)
+    at io.repaint.maven.tiles.NotDefaultModelCache$Key.<init> (NotDefaultModelCache.groovy:54)
+    at io.repaint.maven.tiles.NotDefaultModelCache.get (NotDefaultModelCache.groovy:29)
+    at org.apache.maven.model.building.DefaultModelBuilder.getCache (DefaultModelBuilder.java:1363)
+    at org.apache.maven.model.building.DefaultModelBuilder.readParent (DefaultModelBuilder.java:852)
+    at org.apache.maven.model.building.DefaultModelBuilder.build (DefaultModelBuilder.java:344)
+    at org.apache.maven.model.building.DefaultModelBuilder.build (DefaultModelBuilder.java:252)
+    at org.apache.maven.model.building.ModelBuilder$build.call (Unknown Source)
+    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall (CallSiteArray.java:47)
+    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call (AbstractCallSite.java:125)
+    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call (AbstractCallSite.java:139)
+    at io.repaint.maven.tiles.TilesMavenLifecycleParticipant.thunkModelBuilder (TilesMavenLifecycleParticipant.groovy:518)
+    at io.repaint.maven.tiles.TilesMavenLifecycleParticipant.orchestrateMerge (TilesMavenLifecycleParticipant.groovy:424)
+    at io.repaint.maven.tiles.TilesMavenLifecycleParticipant.afterProjectsRead (TilesMavenLifecycleParticipant.groovy:322)
+    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:264)
+    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
+    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
+    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:972)
+    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
+    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
+    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
+    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
+    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
+    at java.lang.reflect.Method.invoke (Method.java:498)
+    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
+    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
+    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
+    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
+[ERROR] 
+[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
+[ERROR] Re-run Maven using the -X switch to enable full debug logging.
+[ERROR] 
+[ERROR] For more information about the errors and possible solutions, please read the following articles:
+[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/InternalErrorException

--- a/src/it/civersion-tiletest-workspace-pom/tile-tile1/pom.xml
+++ b/src/it/civersion-tiletest-workspace-pom/tile-tile1/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.test</groupId>
+    <artifactId>civersion-tiletest-workspace-tile1</artifactId>
+    <version>1</version>
+
+    <packaging>tile</packaging>
+
+    <name>CI Friendly Build Version Maven Tiles Test - Tile1</name>
+
+   
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.repaint.maven</groupId>
+                <artifactId>tiles-maven-plugin</artifactId>
+                <version>2.24</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/civersion-tiletest-workspace-pom/tile-tile1/tile.xml
+++ b/src/it/civersion-tiletest-workspace-pom/tile-tile1/tile.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <foo.bar.tile1>tile1</foo.bar.tile1>
+    </properties>
+</project>

--- a/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
@@ -605,10 +605,6 @@ public class TilesMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 
 			@Override
 			ModelSource2 resolveModel(Parent parent) throws UnresolvableModelException {
-//				if (parent.version == null)
-//					parent.version = "MAIN-SNAPSHOT";	
-//					
-//	
 					
 				return resolveModel(parent.groupId, parent.artifactId, parent.version)
 			}

--- a/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
@@ -605,7 +605,6 @@ public class TilesMavenLifecycleParticipant extends AbstractMavenLifecyclePartic
 
 			@Override
 			ModelSource2 resolveModel(Parent parent) throws UnresolvableModelException {
-					
 				return resolveModel(parent.groupId, parent.artifactId, parent.version)
 			}
 


### PR DESCRIPTION
We have 2 projects A and B with parent ParentA and ParentB
Both use CI friendly §{revision]
A has a dependency to B
For our IDE we have a artifical pom.xml that references ParentA and ParentB

mvn install fails with error:
[ERROR] Internal error: java.lang.NullPointerException: Cannot invoke method hashCode() on null object -> [Help 1]
org.apache.maven.InternalErrorException: Internal error: java.lang.NullPointerException: Cannot invoke method hashCode() on null object
at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:120)
at org.apache.maven.cli.MavenCli.execute (MavenCli.java:972)
at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke (Method.java:498)
at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: java.lang.NullPointerException: Cannot invoke method hashCode() on null object
at org.codehaus.groovy.runtime.NullObject.hashCode (NullObject.java:174)
at org.codehaus.groovy.runtime.NullObject$hashCode.call (Unknown Source)
at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall (CallSiteArray.java:47)
at org.codehaus.groovy.runtime.callsite.NullCallSite.call (NullCallSite.java:34)
at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall (CallSiteArray.java:47)
at java_lang_String$hashCode.call (Unknown Source)
at io.repaint.maven.tiles.NotDefaultModelCache$Key. (NotDefaultModelCache.groovy:54)
at io.repaint.maven.tiles.NotDefaultModelCache.get (NotDefaultModelCache.groovy:29)
at org.apache.maven.model.building.DefaultModelBuilder.getCache (DefaultModelBuilder.java:1363)
at org.apache.maven.model.building.DefaultModelBuilder.readParent (DefaultModelBuilder.java:852)
at org.apache.maven.model.building.DefaultModelBuilder.build (DefaultModelBuilder.java:344)
at org.apache.maven.model.building.DefaultModelBuilder.build (DefaultModelBuilder.java:252)
at org.apache.maven.model.building.ModelBuilder$build.call (Unknown Source)
at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall (CallSiteArray.java:47)
at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call (AbstractCallSite.java:125)
at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call (AbstractCallSite.java:139)
at io.repaint.maven.tiles.TilesMavenLifecycleParticipant.thunkModelBuilder
...

see maven-tiles\src\it\civersion-tiletest-workspace-pom\readme.md