### PR TITLE
Make plugin compatible with Maven3 and Maven4

### DIFF
--- a/src/main/groovy/io/repaint/maven/tiles/TilesProjectBuilder.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TilesProjectBuilder.groovy
@@ -9,44 +9,47 @@ import org.apache.maven.artifact.versioning.VersionRange
 import org.apache.maven.model.Dependency
 import org.apache.maven.model.Plugin
 import org.apache.maven.model.building.ModelSource
-import org.apache.maven.project.DefaultProjectBuilder
 import org.apache.maven.project.MavenProject
 import org.apache.maven.project.ProjectBuilder
 import org.apache.maven.project.ProjectBuildingException
 import org.apache.maven.project.ProjectBuildingRequest
 import org.apache.maven.project.ProjectBuildingResult
 import org.codehaus.plexus.component.annotations.Component
+import org.codehaus.plexus.component.annotations.Requirement
 
 import static io.repaint.maven.tiles.Constants.TILEPLUGIN_ARTIFACT
 import static io.repaint.maven.tiles.Constants.TILEPLUGIN_GROUP
 
 @CompileStatic
 @Component(role = ProjectBuilder.class, hint = "TilesProjectBuilder")
-class TilesProjectBuilder extends DefaultProjectBuilder {
+class TilesProjectBuilder implements ProjectBuilder {
+
+	@Requirement( hint = "default" )
+	private ProjectBuilder delegate;
 
 	@Override
 	ProjectBuildingResult build(File pomFile, ProjectBuildingRequest request) throws ProjectBuildingException {
-		return injectTileDependecies(super.build(pomFile, request))
+		return injectTileDependecies(delegate.build(pomFile, request))
 	}
 
 	@Override
 	ProjectBuildingResult build(ModelSource modelSource, ProjectBuildingRequest request) throws ProjectBuildingException {
-		return injectTileDependecies(super.build(modelSource, request))
+		return injectTileDependecies(delegate.build(modelSource, request))
 	}
 
 	@Override
 	ProjectBuildingResult build(Artifact artifact, ProjectBuildingRequest request) throws ProjectBuildingException {
-		return injectTileDependecies(super.build(artifact, request))
+		return injectTileDependecies(delegate.build(artifact, request))
 	}
 
 	@Override
 	ProjectBuildingResult build(Artifact artifact, boolean allowStubModel, ProjectBuildingRequest request) throws ProjectBuildingException {
-		return injectTileDependecies(super.build(artifact, allowStubModel, request))
+		return injectTileDependecies(delegate.build(artifact, allowStubModel, request))
 	}
 
 	@Override
 	List<ProjectBuildingResult> build(List<File> pomFiles, boolean recursive, ProjectBuildingRequest request) throws ProjectBuildingException {
-		return injectTileDependecies(super.build(pomFiles, recursive, request))
+		return injectTileDependecies(delegate.build(pomFiles, recursive, request))
 	}
 
 	@CompileStatic(TypeCheckingMode.SKIP)

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -16,18 +16,6 @@
 	<components>
 
 		<component>
-			<role>org.apache.maven.project.ProjectBuilder</role>
-			<role-hint>default</role-hint>
-			<implementation>io.repaint.maven.tiles.TilesProjectBuilder</implementation>
-		</component>
-
-		<component>
-			<role>org.apache.maven.AbstractMavenLifecycleParticipant</role>
-			<role-hint>TilesMavenLifecycleParticipant</role-hint>
-			<implementation>io.repaint.maven.tiles.TilesMavenLifecycleParticipant</implementation>
-		</component>
-
-		<component>
 			<role>org.apache.maven.artifact.handler.ArtifactHandler</role>
 			<role-hint>tile</role-hint>
 			<implementation>org.apache.maven.artifact.handler.DefaultArtifactHandler</implementation>


### PR DESCRIPTION
Instead to extend just delegate to project builder, and have it injected, so stay safe from field vs ctor injection change between 3 and 4.

Clear up components.xml as well, as the two component are discovered by plexus metadata plugin, just the artifactHandler and lifecycleMapping needs to be present in XML.