### PR TITLE
Fixes

### DIFF
--- a/src/main/groovy/io/repaint/maven/tiles/TileArtifactHandlerProvider.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TileArtifactHandlerProvider.groovy
@@ -1,32 +1,28 @@
 package io.repaint.maven.tiles
 
-import com.google.inject.Singleton
-import groovy.transform.CompileStatic
 import org.apache.maven.artifact.handler.ArtifactHandler
 import org.apache.maven.artifact.handler.DefaultArtifactHandler
 
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Provider
+import javax.inject.Singleton
 
-@CompileStatic
 @Singleton
 @Named("tile")
 final class TileArtifactHandlerProvider
 		implements Provider<ArtifactHandler>
 {
-	private final ArtifactHandler artifactHandler;
+	private final DefaultArtifactHandler artifactHandler;
 
 	@Inject
 	TileArtifactHandlerProvider()
 	{
-		this.artifactHandler = new DefaultArtifactHandler(
-				type: "tile",
-				extension: "xml",
-				packaging: "tile",
-				language: "xml",
-				addedToClasspath: false
-		);
+		this.artifactHandler = new DefaultArtifactHandler("tile")
+		this.artifactHandler.extension = "xml"
+		this.artifactHandler.packaging = "tile" // Groovy magic again
+		this.artifactHandler.language = "xml"
+		this.artifactHandler.addedToClasspath = false
 	}
 
 	@Override

--- a/src/main/groovy/io/repaint/maven/tiles/TileLifecycleMappingProvider.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TileLifecycleMappingProvider.groovy
@@ -1,6 +1,5 @@
 package io.repaint.maven.tiles
 
-import com.google.inject.Singleton
 import org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping
 import org.apache.maven.lifecycle.mapping.Lifecycle
 import org.apache.maven.lifecycle.mapping.LifecycleMapping
@@ -9,6 +8,7 @@ import org.apache.maven.lifecycle.mapping.LifecyclePhase
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Provider
+import javax.inject.Singleton
 
 @Singleton
 @Named("tile")

--- a/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
@@ -17,7 +17,6 @@
  **********************************************************************************************************************/
 package io.repaint.maven.tiles
 
-import com.google.inject.Singleton
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import org.apache.maven.AbstractMavenLifecycleParticipant
@@ -76,6 +75,7 @@ import org.xml.sax.SAXParseException
 
 import javax.inject.Inject
 import javax.inject.Named
+import javax.inject.Singleton
 
 import static io.repaint.maven.tiles.Constants.TILEPLUGIN_ARTIFACT
 import static io.repaint.maven.tiles.Constants.TILEPLUGIN_GROUP
@@ -532,13 +532,13 @@ class TilesMavenLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
 		}
 
-		((DefaultModelBuilder)modelBuilder).setModelProcessor(delegateModelProcessor)
+		DefaultModelBuilder mb = ((DefaultModelBuilder)modelBuilder).setModelProcessor(delegateModelProcessor)
 		try {
-			ModelBuildingResult interimBuild = modelBuilder.build(request)
+			ModelBuildingResult interimBuild = mb.build(request)
 
 			// this will revert the tile dependencies inserted by TilesProjectBuilder, which is fine since by now they
 			// served their purpose of correctly ordering projects, so we can now do without them
-			ModelBuildingResult finalModel = modelBuilder.build(request, interimBuild)
+			ModelBuildingResult finalModel = mb.build(request, interimBuild)
 			if (!tilesInjected && applyBeforeParent) {
 				throw new MavenExecutionException("Cannot apply tiles, the expected parent ${applyBeforeParent} is not found.",
 					project.file)

--- a/src/main/groovy/io/repaint/maven/tiles/TilesProjectBuilder.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TilesProjectBuilder.groovy
@@ -1,6 +1,5 @@
 package io.repaint.maven.tiles
 
-import com.google.inject.Singleton
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
 import org.apache.maven.MavenExecutionException
@@ -18,6 +17,7 @@ import org.apache.maven.project.ProjectBuildingResult
 
 import javax.inject.Inject
 import javax.inject.Named
+import javax.inject.Singleton
 
 import static io.repaint.maven.tiles.Constants.TILEPLUGIN_ARTIFACT
 import static io.repaint.maven.tiles.Constants.TILEPLUGIN_GROUP


### PR DESCRIPTION
1st: sadly https://github.com/repaint-io/maven-tiles/pull/134 contained some mistakes (mixed javax.inject and google.inject annotations), fixed

2nd: ModelBuilder handling improved but still fails with 4-alpha-2 as it contains other incompatible changes (this time with ModelProcessor), still these changes are correct and work with mvn3, but does not fix plugin to work with mvn4alpha2

We will work on restoring compat and hopefully alpha3 will have the changes to make this plugin WITH THESE changes work.