### PR TITLE
Fix distribution management snapshot repository load

### DIFF
--- a/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
@@ -371,7 +371,7 @@ class TilesMavenLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 			if (distributionManagement.snapshotRepository) {
 
 				ArtifactRepository repo = new MavenArtifactRepository(
-						distributionManagement.repository.id,
+						distributionManagement.snapshotRepository.id,
 						getSnapshotDistributionManagementRepositoryUrl(project),
 						repositoryFactory.layout,
 						getArtifactRepositoryPolicy(distributionManagement.snapshotRepository.snapshots),


### PR DESCRIPTION
This typo when getting the ID can lead to this error when there's only a snapshot repository in the distribution management
```
[ERROR] Internal error: java.lang.NullPointerException: Cannot invoke "org.apache.maven.model.DeploymentRepository.getId()" because the return value of "org.apache.maven.model.DistributionManagement.getRepository()" is null -> [Help 1]
org.apache.maven.InternalErrorException: Internal error: java.lang.NullPointerException: Cannot invoke "org.apache.maven.model.DeploymentRepository.getId()" because the return value of "org.apache.maven.model.DistributionManagement.getRepository()" is null
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:109)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:906)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:206)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:568)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:283)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:226)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:407)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:348)
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.maven.model.DeploymentRepository.getId()" because the return value of "org.apache.maven.model.DistributionManagement.getRepository()" is null
    at io.repaint.maven.tiles.TilesMavenLifecycleParticipant.discoverAndSetDistributionManagementArtifactoryRepositoriesIfTheyExist (TilesMavenLifecycleParticipant.groovy:374)
    at io.repaint.maven.tiles.TilesMavenLifecycleParticipant.afterProjectsRead (TilesMavenLifecycleParticipant.groovy:338)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:223)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:906)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:206)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:77)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:568)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:283)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:226)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:407)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:348)

```