### PR TITLE
distribution management repositories losing authentication settings

### DIFF
--- a/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
+++ b/src/main/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipant.groovy
@@ -361,28 +361,35 @@ class TilesMavenLifecycleParticipant extends AbstractMavenLifecycleParticipant {
 
 		if (distributionManagement) {
 			if (distributionManagement.repository) {
-
-				ArtifactRepositoryLayout layout = repositoryLayouts.get(distributionManagement.repository.layout);
-				MavenArtifactRepository repo = new MavenArtifactRepository(
-						distributionManagement.repository.id,
-						getReleaseDistributionManagementRepositoryUrl(project),
-						layout,
-						getArtifactRepositoryPolicy(distributionManagement.repository.snapshots),
-						getArtifactRepositoryPolicy(distributionManagement.repository.releases))
-				project.setReleaseArtifactRepository(repo)
+				var candidate = project.getRemoteArtifactRepositories().find {	it.id == distributionManagement.repository.id }
+				if( candidate !=null && candidate instanceof MavenArtifactRepository) {
+					project.setReleaseArtifactRepository(candidate)
+				} else {
+					ArtifactRepositoryLayout layout = repositoryLayouts.get(distributionManagement.repository.layout);
+					MavenArtifactRepository repo = new MavenArtifactRepository(
+							distributionManagement.repository.id,
+							getReleaseDistributionManagementRepositoryUrl(project),
+							layout,
+							getArtifactRepositoryPolicy(distributionManagement.repository.snapshots),
+							getArtifactRepositoryPolicy(distributionManagement.repository.releases))
+					project.setReleaseArtifactRepository(repo)
+				}
 
 			}
 			if (distributionManagement.snapshotRepository) {
-
-				ArtifactRepositoryLayout layout = repositoryLayouts.get(distributionManagement.snapshotRepository.layout);
-				MavenArtifactRepository repo = new MavenArtifactRepository(
-						distributionManagement.snapshotRepository.id,
-						getSnapshotDistributionManagementRepositoryUrl(project),
-						layout,
-						getArtifactRepositoryPolicy(distributionManagement.snapshotRepository.snapshots),
-						getArtifactRepositoryPolicy(distributionManagement.snapshotRepository.releases))
-				project.setSnapshotArtifactRepository(repo)
-
+				var candidate = project.getRemoteArtifactRepositories().find {	it.id == distributionManagement.snapshotRepository.id }
+				if( candidate !=null && candidate instanceof MavenArtifactRepository) {
+					project.setSnapshotArtifactRepository(candidate)
+				} else {
+					ArtifactRepositoryLayout layout = repositoryLayouts.get(distributionManagement.snapshotRepository.layout);
+					MavenArtifactRepository repo = new MavenArtifactRepository(
+							distributionManagement.snapshotRepository.id,
+							getSnapshotDistributionManagementRepositoryUrl(project),
+							layout,
+							getArtifactRepositoryPolicy(distributionManagement.snapshotRepository.snapshots),
+							getArtifactRepositoryPolicy(distributionManagement.snapshotRepository.releases))
+					project.setSnapshotArtifactRepository(repo)
+				}
 			}
 		}
 	}

--- a/src/test/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipantTest.groovy
+++ b/src/test/groovy/io/repaint/maven/tiles/TilesMavenLifecycleParticipantTest.groovy
@@ -560,8 +560,16 @@ public class TilesMavenLifecycleParticipantTest {
 		def participant = new TilesMavenLifecycleParticipant()
 		participant.discoverAndSetDistributionManagementArtifactoryRepositoriesIfTheyExist(project);
 
-		assert project.releaseArtifactRepository.authentication!=null;
-		assert project.snapshotArtifactRepository.authentication!=null;
+
+		def releaseAuthentication = project.releaseArtifactRepository.authentication
+		assert releaseAuthentication !=null;
+		assert releaseAuthentication.username == "username"
+		assert releaseAuthentication.password == "secret"
+
+		def snapshotAuthentication = project.snapshotArtifactRepository.authentication
+		assert snapshotAuthentication !=null;
+		assert snapshotAuthentication.username == "username"
+		assert snapshotAuthentication.password == "secret"
 	}
 
 	protected static Model createBasicModel() {


### PR DESCRIPTION
By just creating a new MavenRepository, the authentication settings of the repositories get removed. The additional code reuses the existing repos before creating a new one without auth.