### PR TITLE
explicitely define m-jar-p version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,12 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>3.3.0</version>
         <executions>


### PR DESCRIPTION
instead of implicitely using the one defined in Maven core